### PR TITLE
Fix panic problem

### DIFF
--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -14,7 +14,7 @@ pub(crate) fn catch_mapping<T: Dto>(map: &mut HashMap<String, String>, option: &
     if let Some(s) = option { s.mapping(map); }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct NacosConfig {
     scheme: String,
     nacos_ip: String,


### PR DESCRIPTION
In use I found a panic problem:

thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: reqwest::Error { kind: Request, url: Url { scheme: "http", cannot_be_a_base: false, username: "", password: None, host: ..., fragment: None }, source: TimedOut }', /Users/clia/.cargo/registry/src/rsproxy.cn-8f6827c7555bfaf8/nacos-api-0.2.1/src/integration/configs.rs:57:72
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: JoinError::Panic(...)', /Users/clia/.cargo/registry/src/rsproxy.cn-8f6827c7555bfaf8/nacos-api-0.2.1/src/integration/configs.rs:45:18

And I did some code fix.
